### PR TITLE
Added Teams to TokenFinder

### DIFF
--- a/TokenFinder.py
+++ b/TokenFinder.py
@@ -12,7 +12,7 @@ import shutil
 
 dbghelp = ctypes.windll.dbghelp
 
-known_processes = ["WINWORD", "ONENOTE", "POWERPNT", "OUTLOOK", "EXCEL", "OneDrive"]
+known_processes = ["WINWORD", "ONENOTE", "POWERPNT", "OUTLOOK", "EXCEL", "OneDrive", "Teams"]
 
 
 def createMiniDump(pid, file_name):
@@ -107,8 +107,7 @@ def create_dump_files():
             pass
 
         for pair in process_pairs:
-            createMiniDump(pair[0], "Dump/" + str(pair[1]) + ".DMP")
-
+            createMiniDump(pair[0], "Dump/" + str(pair[0]) + ".DMP")
         return True
     except:
         return False


### PR DESCRIPTION
Hi,

Thank you for your tool! For our use case, we needed it to work with Teams. I achieved this by adding the Teams process to the known_processes list. Since Teams has multiple processes running, I had to dump all PIDs to find the keys. However, it currently creates a dump file named after the process name. To make this work, I had to change it to use the PID. This way, it downloaded multiple dumps for the different Teams processes and retrieved the key.


![image](https://github.com/doredry/TokenFinder/assets/129975292/e786fc01-2f49-4550-8155-1b809f0b1107)



